### PR TITLE
restrict roboto routing to /robots.txt instead of root so dont break other rails engine

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Roboto::Engine.routes.draw do
-  get '/robots.txt' => 'Robots#show'
+  get '/' => 'Robots#show'
 end
 

--- a/lib/roboto/routing.rb
+++ b/lib/roboto/routing.rb
@@ -3,7 +3,7 @@ module Roboto
   module Routing
     # convenience function for mounting the roboto rails engine to root
     def mount_roboto
-      mount Roboto::Engine => "/"
+      mount Roboto::Engine => "/robots.txt"
     end
   end
 end


### PR DESCRIPTION
This PR fixes mount_roboto routing when having multiple engine mounted for example : Spree.

Could'nt write test for this one, couldn't bundle correctly with nokogiri installation...
However manually tested and pushed to production.

Thanks !
Stephane
