### PR TITLE
In Rails 4, the uppercased controller name in routes.rb causes an error. Switch it to lower case.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Roboto::Engine.routes.draw do
-  get '/' => 'Robots#show'
+  get '/' => 'robots#show'
 end
 


### PR DESCRIPTION
Title says it all.
