### PR TITLE
trim newlines in ERB closing tags

### DIFF
--- a/lib/roboto/content_provider.rb
+++ b/lib/roboto/content_provider.rb
@@ -10,7 +10,7 @@ module Roboto
 
       @contents = File.read(path)
       if path.extname == '.erb'
-        @contents = ERB.new(@contents).result(custom_binding ? custom_binding : binding)
+        @contents = ERB.new(@contents, nil, '>').result(custom_binding ? custom_binding : binding)
       end
       @contents
     end

--- a/spec/roboto/content_provider_spec.rb
+++ b/spec/roboto/content_provider_spec.rb
@@ -29,6 +29,13 @@ describe Roboto::ContentProvider do
     content_provider.contents.should eql(Rails.env)
   end
 
+  it 'strips newlines in closing erb tags' do
+    path = Rails.root.join("config/robots/test.txt.erb")
+    File.open(path, 'wb') { |f| f.write("<% if true %>\n<%= Rails.env %>\n<% end %>") }
+    content_provider.path.should eql(path)
+    content_provider.contents.should eql(Rails.env)
+  end
+
   it 'uses the default robots file if found in the rails root' do
     path = Rails.root.join(relative_path_to_default)
     FileUtils.touch(path)


### PR DESCRIPTION
The robots.txt spec doesn't mention newlines at the top of the file but given the importance to robots.txt to ecommerce sites, I'd rather be safe about keeping a clean file.

This is a simple instruction to the ERB constructor to eat newlines on lines ending with %> primarily so I don't have a newline at the top of my robots.txt

http://ruby-doc.org/stdlib-2.1.2/libdoc/erb/rdoc/ERB.html#method-c-new
